### PR TITLE
Check for task cancellation in prepare, generate, and model load

### DIFF
--- a/Libraries/Embedders/Tokenizer.swift
+++ b/Libraries/Embedders/Tokenizer.swift
@@ -25,7 +25,13 @@ func loadTokenizerConfig(configuration: ModelConfiguration, hub: HubApi) async t
             // the load can fail (async when we try to use it)
             let loaded = LanguageModelConfigurationFromHub(
                 modelName: configuration.tokenizerId ?? id, hubApi: hub)
+            
+            try Task.checkCancellation()
+            
             _ = try await loaded.tokenizerConfig
+            
+            try Task.checkCancellation()
+            
             config = loaded
         } catch {
             let nserror = error as NSError
@@ -47,6 +53,12 @@ func loadTokenizerConfig(configuration: ModelConfiguration, hub: HubApi) async t
     guard let tokenizerConfig = try await config.tokenizerConfig else {
         throw EmbedderError(message: "missing config")
     }
+    
+    try Task.checkCancellation()
+    
     let tokenizerData = try await config.tokenizerData
+    
+    try Task.checkCancellation()
+    
     return (tokenizerConfig, tokenizerData)
 }

--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -24,7 +24,7 @@ extension LLMModel {
         while y.tokens.size > prefillStepSize {
             let input = y[.newAxis, ..<prefillStepSize]
             let result = self(input, cache: cache.isEmpty ? nil : cache, state: state)
-            eval(cache)
+            try batchedEval(cache)
             y = y[prefillStepSize...]
         }
 

--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -24,7 +24,10 @@ extension LLMModel {
         while y.tokens.size > prefillStepSize {
             let input = y[.newAxis, ..<prefillStepSize]
             let result = self(input, cache: cache.isEmpty ? nil : cache, state: state)
-            try batchedEval(cache)
+            
+            try Task.checkCancellation()
+            
+            eval(cache)
             y = y[prefillStepSize...]
         }
 

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -210,7 +210,11 @@ private struct LLMUserInputProcessor: UserInputProcessor {
             let messages = input.prompt.asMessages()
             let promptTokens = try tokenizer.applyChatTemplate(
                 messages: messages, tools: input.tools, additionalContext: input.additionalContext)
-            return LMInput(tokens: MLXArray(promptTokens))
+            try Task.checkCancellation()
+            let input = LMInput(tokens: MLXArray(promptTokens))
+            return input
+        } catch (let cancellationError as CancellationError) {
+            throw cancellationError // just rethrow
         } catch {
             // #150 -- it might be a TokenizerError.chatTemplate("No chat template was specified")
             // but that is not public so just fall back to text
@@ -219,6 +223,7 @@ private struct LLMUserInputProcessor: UserInputProcessor {
                 .compactMap { $0["content"] as? String }
                 .joined(separator: ". ")
             let promptTokens = tokenizer.encode(text: prompt)
+            try Task.checkCancellation()
             return LMInput(tokens: MLXArray(promptTokens))
         }
     }
@@ -257,20 +262,29 @@ public class LLMModelFactory: ModelFactory {
         // download weights and config
         let modelDirectory = try await downloadModel(
             hub: hub, configuration: configuration, progressHandler: progressHandler)
+        
+        try Task.checkCancellation()
 
         // load the generic config to unerstand which model and how to load the weights
         let configurationURL = modelDirectory.appending(component: "config.json")
         let baseConfig = try JSONDecoder().decode(
             BaseConfiguration.self, from: Data(contentsOf: configurationURL))
+        
         let model = try typeRegistry.createModel(
             configuration: configurationURL, modelType: baseConfig.modelType)
+        
+        try Task.checkCancellation()
 
         // apply the weights to the bare model
         try loadWeights(
             modelDirectory: modelDirectory, model: model, quantization: baseConfig.quantization)
-
+        
+        try Task.checkCancellation()
+        
         let tokenizer = try await loadTokenizer(configuration: configuration, hub: hub)
-
+        
+        try Task.checkCancellation()
+        
         return .init(
             configuration: configuration, model: model,
             processor: LLMUserInputProcessor(tokenizer: tokenizer, configuration: configuration),

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -331,6 +331,7 @@ public struct TokenIterator: Sequence, IteratorProtocol {
 
             // evaluate the remainder of the prompt -- this primes the pump
             let token = step(previous: y)
+            try Task.checkCancellation()
             y = .init(tokens: token)
             asyncEval(y.tokens)
 
@@ -340,6 +341,7 @@ public struct TokenIterator: Sequence, IteratorProtocol {
 
             break
         }
+        try Task.checkCancellation()
     }
 
     mutating func convertToToken(logits: MLXArray) -> MLXArray {
@@ -474,7 +476,7 @@ public func generate(
         configuration: configuration, model: model, processor: StandInUserInputProcessor(),
         tokenizer: tokenizer)
 
-    return generate(
+    return try generate(
         input: input, context: context, iterator: iterator, didGenerate: didGenerate)
 }
 
@@ -510,7 +512,7 @@ public func generate(
 ) throws -> GenerateResult {
     let iterator = try TokenIterator(
         input: input, model: context.model, parameters: parameters)
-    return generate(
+    return try generate(
         input: input, context: context, iterator: iterator, didGenerate: didGenerate)
 }
 
@@ -528,7 +530,7 @@ public func generate(
     input: LMInput, context: ModelContext,
     iterator: TokenIterator,
     didGenerate: ([Int]) -> GenerateDisposition
-) -> GenerateResult {
+) throws -> GenerateResult {
     var start = Date.timeIntervalSinceReferenceDate
     var promptTime: TimeInterval = 0
 
@@ -558,6 +560,10 @@ public func generate(
         if didGenerate(tokens) == .stop {
             break
         }
+        
+        if Task.isCancelled {
+            break // instead of checkCancellation so that Stream().synchronize() gets called
+        }
     }
 
     let now = Date.timeIntervalSinceReferenceDate
@@ -568,6 +574,8 @@ public func generate(
     // hit assertions as the mlx scheduler is torn down.  Synchronize with the stream
     // to make sure it is complete.
     Stream().synchronize()
+    
+    try Task.checkCancellation() // check now, so that throw happens
 
     return GenerateResult(
         inputText: input.text, tokens: tokens,

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -29,7 +29,9 @@ public func loadTokenizerConfig(configuration: ModelConfiguration, hub: HubApi) 
             // the load can fail (async when we try to use it)
             let loaded = LanguageModelConfigurationFromHub(
                 modelName: configuration.tokenizerId ?? id, hubApi: hub)
+            try Task.checkCancellation()
             _ = try await loaded.tokenizerConfig
+            try Task.checkCancellation()
             config = loaded
         } catch {
             let nserror = error as NSError

--- a/Libraries/MLXVLM/Models/Idefics3.swift
+++ b/Libraries/MLXVLM/Models/Idefics3.swift
@@ -811,6 +811,7 @@ public class Idefics3Processor: UserInputProcessor {
             // No image scenario
             let tokens = try tokenizer.encode(text: prompt)
             let tokensArray = MLXArray(tokens).expandedDimensions(axis: 0)
+            try Task.checkCancellation()
             let mask = ones(like: tokensArray)
             return LMInput(text: .init(tokens: tokensArray, mask: mask), image: nil)
         } else {
@@ -832,12 +833,17 @@ public class Idefics3Processor: UserInputProcessor {
 
             var image = try input.images[0].asCIImage()
             image = MediaProcessing.inSRGBToneCurveSpace(image)
+            
+            try Task.checkCancellation()
+            
             let targetSize = CGSize(
                 width: fixedImageSize,
                 height: fixedImageSize
             )
             image = MediaProcessing.apply(image, processing: input.processing)
+            try Task.checkCancellation()
             image = MediaProcessing.resampleBicubic(image, to: targetSize)
+            try Task.checkCancellation()
             image = MediaProcessing.normalize(
                 image,
                 mean: config.imageMeanTuple,
@@ -863,6 +869,7 @@ public class Idefics3Processor: UserInputProcessor {
             {
                 pixels = pixels.transposed(0, 2, 3, 1)
             }
+            try Task.checkCancellation()
 
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask),

--- a/Libraries/MLXVLM/Models/Paligemma.swift
+++ b/Libraries/MLXVLM/Models/Paligemma.swift
@@ -485,12 +485,18 @@ public class PaligGemmaProcessor: UserInputProcessor {
         prompt =
             Array(repeating: "<image>", count: count).joined() + (tokenizer.bosToken ?? "") + prompt
             + "\n"
-
+        
+        try Task.checkCancellation()
+        
         let promptTokens = try tokenizer.encode(text: prompt)
         let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
+        
+        try Task.checkCancellation()
+        
         let mask = ones(like: promptArray).asType(.int8)
 
         let pixels = try prepare(image: input.images[0].asCIImage(), processing: input.processing)
+        try Task.checkCancellation()
 
         return LMInput(text: .init(tokens: promptArray, mask: mask), image: .init(pixels: pixels))
     }


### PR DESCRIPTION
Added `Task.checkCancellation()` to multiple places across `load`, `prepare` and `generate`.

Related issues:
https://github.com/ml-explore/mlx-swift-examples/issues/227
https://github.com/ml-explore/mlx-swift-examples/issues/230

